### PR TITLE
fix: add summary_image_large content to force larger images

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,6 +33,7 @@ function Home(): JSX.Element {
         <meta property="og:url" content="https://pleasantcord.namchee.dev"></meta>
         <meta property="og:type" content="website"></meta>
         <meta property="og:description" content={metaDesc}></meta>
+        <meta name="twitter:card" content="summary_large_image"></meta>
       </Head>
       <div
         className="flex-1


### PR DESCRIPTION
## Overview

This pull request adds `twitter:card` meta tag with `summary_image_large` to fix small images when the web is posted via Twitter or Discord.