### PR TITLE
fix: use form keys to force config form refresh

### DIFF
--- a/src/components/DashboardHeader/DashboardHeader.tsx
+++ b/src/components/DashboardHeader/DashboardHeader.tsx
@@ -16,7 +16,8 @@ function Topnav(): JSX.Element {
     >
       <div
         className="flex items-center
-        space-x-4"
+        space-x-2
+        md:space-x-4"
       >
         <h1
           className="text-28px

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -15,22 +15,16 @@ function ServerDashboard(): JSX.Element {
   const { query } = useRouter();
   const { id } = query;
 
-  const { data: headerData } = useSWR(['/api/servers', id], (url, id) => {
-    if (!id) {
-      return null;
-    }
-
-    return fetcher(`${url}/${id}`);
-  });
+  const { data: headerData } = useSWR(
+    id ? ['/api/servers', id] : null,
+    (url, id) => fetcher(`${url}/${id}`),
+  );
 
   const { data: categoriesData } = useSWR('/api/categories', fetcher);
-  const { data: configData } = useSWR(['/api/configs', id], (url, id) => {
-    if (!id) {
-      return null;
-    }
-
-    return fetcher(`${url}/${id}`);
-  });
+  const { data: configData } = useSWR(
+    id ? ['/api/configs', id] : null,
+    (url, id) => fetcher(`${url}/${id}`),
+  );
 
   const header = () => {
     if (!headerData) {
@@ -58,7 +52,10 @@ function ServerDashboard(): JSX.Element {
       return <ConfigForm.Skeleton />;
     }
 
-    return <ConfigForm config={config} categoryList={categories} />;
+    return <ConfigForm
+      key={`server-${id}`}
+      config={config}
+      categoryList={categories} />;
   };
 
   return (

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -37,7 +37,9 @@ function ServerDashboard(): JSX.Element {
       return <ServerInfo.Skeleton />;
     }
 
-    return <ServerInfo server={server} />;
+    return <ServerInfo
+      key={`server-${id}`}
+      server={server} />;
   };
 
   const form = () => {


### PR DESCRIPTION
## Overview

This pull request fixes config form behavior that doesn't refresh correctly when servers are switched from the menu, which made the previous server config being shown as the current server config.

This is due to the missing `key` prop on `ConfigForm` and `ServerInfo` components, so React doesn't know that the component must be refreshed.