### PR TITLE
fix: add refresh token flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-dom": "17.0.2",
     "react-hook-form": "^7.20.2",
     "react-hot-toast": "^2.1.1",
-    "react-lottie": "^1.2.3",
+    "react-lottie-player": "^1.4.1",
     "react-spring": "^9.3.0",
     "swr": "^1.0.1",
     "zod": "^3.11.6"

--- a/src/components/AuthGuard/AuthGuard.tsx
+++ b/src/components/AuthGuard/AuthGuard.tsx
@@ -2,19 +2,24 @@ import * as React from 'react';
 
 import { signIn, useSession } from 'next-auth/react';
 
-import { DISCORD } from '@/constant/provider';
 import { AuthLoader } from '@/components/AuthLoader';
+
+import { DISCORD } from '@/constant/provider';
+import { DISCORD_NOT_AUTH } from '@/constant/error';
 
 function AuthGuard(
   { children }: React.PropsWithChildren<unknown>,
 ): JSX.Element {
-  const { status } = useSession();
+  const { data: session, status } = useSession();
 
   React.useEffect(() => {
-    if (status === 'unauthenticated') {
+    if (
+      status === 'unauthenticated' ||
+      session?.error === DISCORD_NOT_AUTH
+    ) {
       signIn(DISCORD);
     }
-  }, [status]);
+  }, [session, status]);
 
   if (status === 'loading') {
     return <AuthLoader />;

--- a/src/components/AuthLoader/AuthLoader.tsx
+++ b/src/components/AuthLoader/AuthLoader.tsx
@@ -1,21 +1,20 @@
 import * as React from 'react';
 
-import Lottie from 'react-lottie';
+import Lottie from 'react-lottie-player';
 import * as animation from '@/animations/loading.json';
 
 function AuthLoader(): JSX.Element {
-  const opts = {
-    loop: true,
-    autoplay: true,
-    animationData: animation,
-    rendererSettings: {
-      preserveAspectRatio: 'xMidYMid slice',
-    },
-  };
-
   return (
     <div className="flex-1 grid place-items-center bg-background">
-      <Lottie options={opts} width={320} height={320} speed={1.75} />
+      <Lottie
+        loop
+        animationData={animation}
+        play
+        speed={1.75}
+        rendererSettings={{
+          preserveAspectRatio: 'xMidYMid slice',
+        }}
+        className="w-320px h-320px" />
     </div>
   );
 }

--- a/src/components/DashboardHeader/Profile.tsx
+++ b/src/components/DashboardHeader/Profile.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import useSWR from 'swr';
 
-import { signOut } from 'next-auth/react';
+import { signIn, signOut } from 'next-auth/react';
 import { useTransition, animated, config } from 'react-spring';
 
 import * as RadixAvatar from '@radix-ui/react-avatar';
@@ -12,7 +12,10 @@ import { Avatar } from '@/components/Avatar';
 import { Skeleton } from '@/components/Skeleton';
 import { Button } from '@/components/Button';
 
+import { REFRESH_ERROR } from '@/constant/error';
+import { DISCORD } from '@/constant/provider';
 import { CDN_URL } from '@/constant/api';
+
 import { fetcher } from '@/utils/fetcher';
 
 import type { User } from '@/entity/user';
@@ -41,7 +44,11 @@ function Profile(): JSX.Element {
     return <Skeleton className="rounded-full w-12 h-12" />;
   }
 
-  const { data: user } = data;
+  const { data: user, error } = data;
+
+  if (error === REFRESH_ERROR) {
+    signIn(DISCORD);
+  }
 
   if (!user) {
     return <Skeleton className="rounded-full w-12 h-12" />;

--- a/src/components/DashboardHeader/Profile.tsx
+++ b/src/components/DashboardHeader/Profile.tsx
@@ -38,7 +38,7 @@ function Profile(): JSX.Element {
     },
   });
 
-  const { data } = useSWR<APIResponse<User>>('/api/user', fetcher);
+  const { data } = useSWR<APIResponse<User> >('/api/user', fetcher);
 
   if (!data) {
     return <Skeleton className="rounded-full w-12 h-12" />;

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -4,11 +4,15 @@ import Image from 'next/image';
 import Link from 'next/link';
 import useSWR from 'swr';
 
+import { signIn } from 'next-auth/react';
+
 import { ServerItem } from '@/components/ServerItem';
 
 import { fetcher } from '@/utils/fetcher';
 import { PartialServer } from '@/entity/server';
 import { APIResponse } from '@/entity/response';
+import { REFRESH_ERROR } from '@/constant/error';
+import { DISCORD } from '@/constant/provider';
 
 function Menu(): JSX.Element {
   const { data } = useSWR<APIResponse<PartialServer[]>>(
@@ -27,7 +31,11 @@ function Menu(): JSX.Element {
       );
     }
 
-    const { data: servers } = data;
+    const { data: servers, error } = data;
+
+    if (error === REFRESH_ERROR) {
+      signIn(DISCORD);
+    }
 
     if (!servers) {
       return (

--- a/src/constant/error.ts
+++ b/src/constant/error.ts
@@ -1,0 +1,5 @@
+// Discord errors
+export const DISCORD_NOT_AUTH = '401: Unauthorized';
+
+// App errors
+export const REFRESH_ERROR = 'Failed to refresh token';

--- a/src/constant/provider.ts
+++ b/src/constant/provider.ts
@@ -1,1 +1,2 @@
 export const DISCORD = 'discord';
+export const REFRESH_GRANT = 'refresh_token';

--- a/src/entity/error.ts
+++ b/src/entity/error.ts
@@ -1,0 +1,8 @@
+export class APIError extends Error {
+  public constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+  }
+}

--- a/src/next-auth.d.ts
+++ b/src/next-auth.d.ts
@@ -1,10 +1,21 @@
 /* eslint-disable camelcase */
+import { User } from 'next-auth';
+
 import 'next-auth/jwt';
 
 declare module 'next-auth/jwt' {
   interface JWT {
     userId?: string;
     accessToken?: string;
+    accessTokenExpires?: number;
     refreshToken?: string;
+  }
+}
+
+declare module 'next-auth' {
+  interface Session {
+    user?: User;
+    accessToken?: string;
+    error?: string;
   }
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -38,7 +38,7 @@ function NotFoundPage(): JSX.Element {
           Looks like you&apos;re lost!
         </h1>
         <p className="md:text-lg leading-relaxed mt-2 md:mt-4">
-          The page you&apos;re looking for doesn&apos;t exist
+          The resource you&apos;re looking for doesn&apos;t exist
         </p>
         <p className="md:text-lg leading-relaxed">
           Let&apos;s get you back to safety ASAP

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,50 @@
-import NextAuth from 'next-auth';
-
+import NextAuth, { User } from 'next-auth';
 import Discord from 'next-auth/providers/discord';
+
+import { URLSearchParams } from 'url';
+import { JWT } from 'next-auth/jwt';
+
+import { REFRESH_GRANT } from '@/constant/provider';
+import { REFRESH_ERROR } from '@/constant/error';
+
+async function refreshToken(token: JWT): Promise<JWT> {
+  try {
+    const url = 'https://discord.com/api/oauth2/token' +
+      new URLSearchParams({
+        client_id: process.env.DISCORD_CLIENT_ID as string,
+        client_secret: process.env.DISCORD_CLIENT_SECRET as string,
+        grant_type: REFRESH_GRANT,
+        refresh_token: token.refreshToken as string,
+      });
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+
+    const newToken = await response.json();
+
+    if (!response.ok) {
+      throw newToken;
+    }
+
+    return {
+      ...token,
+      accessToken: newToken.access_token,
+      accessTokenExpires: Date.now() + newToken.expires_in * 1000,
+      refreshToken: newToken.refresh_token ?? token.refreshToken,
+    };
+  } catch (err) {
+    console.error(err);
+
+    return {
+      ...token,
+      error: REFRESH_ERROR,
+    };
+  }
+}
 
 export default NextAuth({
   secret: process.env.JWT_SECRET as string,
@@ -19,22 +63,29 @@ export default NextAuth({
     }),
   ],
   callbacks: {
-    async jwt({ token, account }) {
-      if (!account) {
+    async jwt({ token, user, account }) {
+      if (account && user) {
+        return {
+          accessToken: account.access_token,
+          accessTokenExpires: Date.now() + (account.expires_at || 0) * 1000,
+          refreshToken: account.refresh_token,
+          userId: token.sub,
+        };
+      }
+
+      if (!token.accessTokenExpires || Date.now() < token.accessTokenExpires) {
         return token;
       }
 
-      if (account.access_token) {
-        token.accessToken = account.access_token;
-      }
+      return refreshToken(token);
+    },
 
-      if (account.refresh_token) {
-        token.refreshToken = account.refresh_token;
-      }
+    async session({ session, token }) {
+      session.user = token.user as User;
+      session.accessToken = token.accessToken;
+      session.error = token.error as string;
 
-      token.userId = token.sub;
-
-      return token;
+      return session;
     },
   },
 });

--- a/src/pages/api/configs/[id].ts
+++ b/src/pages/api/configs/[id].ts
@@ -45,7 +45,7 @@ async function getServerConfig(
   const serverId = req.query['id'];
 
   if (!serverId || Number.isNaN(serverId)) {
-    return res.status(500).json({
+    return res.status(400).json({
       data: null,
       error: 'Server ID is required and must be an integer',
     });

--- a/src/pages/api/user/index.ts
+++ b/src/pages/api/user/index.ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { getToken } from 'next-auth/jwt';
 
 import { API_URL } from '@/constant/api';
+import { DISCORD_NOT_AUTH, REFRESH_ERROR } from '@/constant/error';
 
 async function getCurrentUser(
   req: NextApiRequest,
@@ -31,14 +32,16 @@ async function getCurrentUser(
     }
   );
 
+  const result = await response.json();
+
   if (!response.ok) {
     return res.status(response.status).json({
       data: null,
-      error: response.statusText,
+      error: result.message === DISCORD_NOT_AUTH ?
+        REFRESH_ERROR :
+        result.message,
     });
   }
-
-  const result = await response.json();
 
   return res.status(200).json({
     data: result,

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -1,1 +1,13 @@
-export const fetcher = (url: string) => fetch(url).then((res) => res.json());
+import { APIError } from '@/entity/error';
+
+export const fetcher = async (url: string) => {
+  const response = await fetch(url);
+  const result = await response.json();
+
+  if (!response.ok) {
+    const err = new APIError(result.error, response.status);
+    throw err;
+  }
+
+  return result;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,14 +970,6 @@ axobject-query@^2.2.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -1254,11 +1246,6 @@ core-js-pure@^3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.0.tgz#db6fdadfdd4dc280ec93b64c3c2e8460e6f10094"
   integrity sha512-UEQk8AxyCYvNAs6baNoPqDADv7BX0AmBLGxVsrAifPPx/C8EAzV4Q+2ZUJqVzfI2TQQEZITnwUkWcHpgc/IubQ==
-
-core-js@^2.4.0:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 create-ecdh@^4.0.0:
   version "4.0.4"
@@ -2454,10 +2441,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-web@^5.1.3:
-  version "5.7.14"
-  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.7.14.tgz#cdabd256181c3ea64cf0c174a61dfa137228981f"
-  integrity sha512-J+QEPse7Rws0XvTqRJNtcE8cszb5FWYFHubEK6bgDJtw64/AQJ40aazbWXsWGBM4sm/PgLBLgmmhDU4QpLiieg==
+lottie-web@^5.7.6:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.8.1.tgz#807e0af0ad22b59bf867d964eb684cb3368da0ef"
+  integrity sha512-9gIizWADlaHC2GCt+D+yNpk5l2clZQFqnVWWIVdY0LnxC/uLa39dYltAe3fcmC/hrZ2IUQ8dLlY0O934Npjs7Q==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -3066,13 +3053,14 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-lottie@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/react-lottie/-/react-lottie-1.2.3.tgz#8544b96939e088658072eea5e12d912cdaa3acc1"
-  integrity sha512-qLCERxUr8M+4mm1LU0Ruxw5Y5Fn/OmYkGfnA+JDM/dZb3oKwVAJCjwnjkj9TMHtzR2U6sMEUD3ZZ1RaHagM7kA==
+react-lottie-player@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-lottie-player/-/react-lottie-player-1.4.1.tgz#ddd448486b8e8a42f4ae149751c38a8539f80b77"
+  integrity sha512-8dw3Dt8h6iTIrA+Iz7N/rOZjY1ShEwoxsgFywW2hZPFf58mZL75NFFNXY6v95NNj/25kZQpMV/bDkNoxj4Sang==
   dependencies:
-    babel-runtime "^6.26.0"
-    lottie-web "^5.1.3"
+    fast-deep-equal "^3.1.3"
+    lodash.clonedeep "^4.5.0"
+    lottie-web "^5.7.6"
 
 react-refresh@0.8.3:
   version "0.8.3"
@@ -3147,11 +3135,6 @@ regenerator-runtime@0.13.4, regenerator-runtime@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz#e96bf612a3362d12bb69f7e8f74ffeab25c7ac91"
   integrity sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==
-
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regexp.prototype.flags@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
## Overview

This pull request adds refresh token rotation to prevent `500` and `401` errors from API when the token has already expired by adding an automated refresh flow. If the token is not refreshable, it will force a login.

This pull request also fixes an issue when a configuration is not found, it will now redirect you to `404` page.

Finally, this pull request replaces `react-lottie` with `react-lottie-player` to avoid react warnings.